### PR TITLE
Stop app when something error happens and print them instead of log.Fatal

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/gdamore/tcell"
-	"github.com/hokaccha/go-prettyjson"
-	"github.com/rivo/tview"
 	"log"
 	"os"
 	"time"
+
+	"github.com/gdamore/tcell"
+	"github.com/hokaccha/go-prettyjson"
+	"github.com/rivo/tview"
 )
 
 var (
@@ -121,7 +122,8 @@ func read() {
 		var value map[string]interface{}
 		err := dec.Decode(&value)
 		if err != nil {
-			log.Fatal(err)
+			log.Println(err)
+			app.Stop()
 		}
 
 		store.Lock()


### PR DESCRIPTION
## WHAT

Print error message when facing some errors while reading JSON and stop running app.

## WHY

If the `red` process ends unexpectedly while `tview` uses special characters to control the terminal, the shell and its prompt on the terminal is broken like the following example.

```console
$ kubectl logs -f test-pod-vgwdr | red severity message
2019/03/26 18:47:43 invalid character 'p' looking for beginning of value
                                                                        [1]    80683 broken pipe  kubectl logs -f test-pod-vgwdr |
                                                                                                                                                                80684 exit 1       red severity message
(1) b4b4r07 ~/.../b4b4r07/red
                             %                                                                                                                                                    (dont-panic-and-stop-app ?)
On branch dont-panic-and-stop-app
                                 Your branch is up to date with 'origin/dont-panic-and-stop-app'.

                                                                                                 Untracked files:
                                                                                                                   (use "git add <file>..." to include in what will be committed)

                                                                                                                                                                                 red

(1) b4b4r07 ~/.../b4b4r07/red
                             %                                                                                                                                                    (dont-panic-and-stop-app ?)
```